### PR TITLE
New new new expression struct

### DIFF
--- a/src/expressions/traits.rs
+++ b/src/expressions/traits.rs
@@ -5,9 +5,11 @@ use std::ops::{BitAnd, BitOr};
 
 use itertools::Itertools;
 
-use crate::expressions::Expression::{self, And, Constant, Literal, Not, Or};
 use crate::parser::{parse_tokens, tokenize, ParseError};
 use crate::traits::{Evaluate, GatherLiterals, Parse, PowerSet, SemanticEq};
+
+use super::Expression;
+use super::ExpressionNode::{And, Constant, Literal, Not, Or};
 
 impl<TLiteral: Debug + Clone + Eq + Hash> SemanticEq<TLiteral> for Expression<TLiteral> {
     fn semantic_eq(&self, other: &Self) -> bool {
@@ -25,7 +27,7 @@ impl<TLiteral: Debug + Clone + Eq + Hash> SemanticEq<TLiteral> for Expression<TL
 
 impl<TLiteral: Debug + Clone + Eq + Hash> GatherLiterals<TLiteral> for Expression<TLiteral> {
     fn gather_literals_rec(&self, current: &mut HashSet<TLiteral>) {
-        match self {
+        match self.node() {
             Literal(l) => {
                 current.insert(l.clone());
             }
@@ -60,7 +62,7 @@ impl<TLiteral: Debug + Clone + Eq + Hash> PowerSet<TLiteral> for Expression<TLit
 
 impl<TLiteral: Debug + Clone + Eq + Hash> Evaluate<TLiteral> for Expression<TLiteral> {
     fn evaluate(&self, literal_values: &HashMap<TLiteral, bool>) -> bool {
-        match self {
+        match self.node() {
             Literal(t) => *literal_values.get(t).unwrap_or(&false),
             Constant(value) => *value,
             And(values) => values.iter().all(|e| e.evaluate(literal_values)),
@@ -73,7 +75,7 @@ impl<TLiteral: Debug + Clone + Eq + Hash> Evaluate<TLiteral> for Expression<TLit
         &self,
         literal_values: &HashMap<TLiteral, bool>,
     ) -> Result<bool, TLiteral> {
-        match self {
+        match self.node() {
             Literal(t) => match literal_values.get(t) {
                 None => Err(t.clone()),
                 Some(valuation) => Ok(*valuation),
@@ -103,7 +105,7 @@ impl Parse for Expression<String> {
 
 impl<TLiteral: Debug + Clone + Eq + Hash + Display> Display for Expression<TLiteral> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        match self {
+        match self.node() {
             Constant(value) => write!(f, "{}", value),
             Literal(name) => write!(f, "{}", name),
             Not(inner) => write!(f, "!{}", inner),
@@ -114,6 +116,86 @@ impl<TLiteral: Debug + Clone + Eq + Hash + Display> Display for Expression<TLite
                     .iter()
                     .fold(String::new(), |acc, elem| format!("{acc} & {elem}"))
             ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::expressions::Expression;
+    use crate::expressions::ExpressionNode::{And, Not, Or};
+    use std::fmt::Debug;
+    use std::hash::Hash;
+
+    /*
+       The following traits are only implemented in test builds because it is not yet
+       clear whether we should provide them as part of the stable Rust API (overloading
+       operators for non-copy types often isn't as useful as it might initially seem).
+
+       However, in tests, we can use them to simplify expression construction.
+    */
+
+    impl<T: Debug + Clone + Eq + Hash> std::ops::BitAnd<Expression<T>> for Expression<T> {
+        type Output = Expression<T>;
+
+        fn bitand(self, rhs: Expression<T>) -> Self::Output {
+            let mut es = Vec::new();
+            match (self.node(), rhs.node()) {
+                (And(es1), And(es2)) => {
+                    es.extend(es1.iter().cloned());
+                    es.extend(es2.iter().cloned());
+                }
+                (And(es1), _other) => {
+                    es.extend(es1.iter().cloned());
+                    es.push(rhs);
+                }
+                (_other, And(es2)) => {
+                    es.push(self);
+                    es.extend(es2.iter().cloned());
+                }
+                _ => {
+                    es.push(self);
+                    es.push(rhs);
+                }
+            }
+
+            And(es).into()
+        }
+    }
+
+    impl<T: Debug + Clone + Eq + Hash> std::ops::BitOr<Expression<T>> for Expression<T> {
+        type Output = Expression<T>;
+
+        fn bitor(self, rhs: Expression<T>) -> Self::Output {
+            let mut es = Vec::new();
+            match (self.node(), rhs.node()) {
+                (Or(es1), Or(es2)) => {
+                    es.extend(es1.iter().cloned());
+                    es.extend(es2.iter().cloned());
+                }
+                (Or(es1), _other) => {
+                    es.extend(es1.iter().cloned());
+                    es.push(rhs);
+                }
+                (_other, Or(es2)) => {
+                    es.push(self);
+                    es.extend(es2.iter().cloned());
+                }
+                _ => {
+                    es.push(self);
+                    es.push(rhs);
+                }
+            }
+
+            Or(es).into()
+        }
+    }
+
+    impl<T: Debug + Clone + Eq + Hash> std::ops::Not for Expression<T> {
+        type Output = Expression<T>;
+
+        fn not(self) -> Self::Output {
+            Not(self).into()
         }
     }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -1,7 +1,5 @@
-use itertools::Itertools;
-use std::sync::Arc;
-
 use crate::expressions::Expression;
+use crate::expressions::ExpressionNode::{And, Constant, Literal, Not, Or};
 use crate::parser::error::ParseTokensError;
 use crate::parser::structs::FinalToken;
 
@@ -10,45 +8,44 @@ pub fn parse_tokens(input: &[FinalToken]) -> Result<Expression<String>, ParseTok
 }
 
 fn priority_0_parse_or(data: &[FinalToken]) -> Result<Expression<String>, ParseTokensError> {
-    data.split(|t| t == &FinalToken::Or)
-        .map(priority_1_parse_and)
-        .fold_ok(None::<Expression<String>>, |acc, item| match acc {
-            None => Some(item),
-            Some(Expression::Or(mut es)) => {
-                es.push(Arc::new(item));
-                Some(Expression::Or(es))
-            }
-            Some(previous) => Some(Expression::n_ary_or(vec![previous, item])),
-        })?
-        .ok_or(ParseTokensError::EmptySideOfOperator)
+    let mut es = Vec::new();
+    for group in data.split(|t| t == &FinalToken::Or) {
+        es.push(priority_1_parse_and(group)?);
+    }
+
+    match es.len() {
+        0 => Err(ParseTokensError::EmptySideOfOperator),
+        1 => Ok(es.remove(0)),
+        _ => Ok(Or(es).into()),
+    }
 }
 
 fn priority_1_parse_and(data: &[FinalToken]) -> Result<Expression<String>, ParseTokensError> {
-    data.split(|t| t == &FinalToken::And)
-        .map(priority_2_terminal)
-        .fold_ok(None::<Expression<String>>, |acc, item| match acc {
-            None => Some(item),
-            Some(Expression::And(mut es)) => {
-                es.push(Arc::new(item));
-                Some(Expression::And(es))
-            }
-            Some(previous) => Some(Expression::n_ary_and(vec![previous, item])),
-        })?
-        .ok_or(ParseTokensError::EmptySideOfOperator)
+    let mut es = Vec::new();
+    for group in data.split(|t| t == &FinalToken::And) {
+        es.push(priority_2_terminal(group)?);
+    }
+
+    match es.len() {
+        0 => Err(ParseTokensError::EmptySideOfOperator),
+        1 => Ok(es.remove(0)),
+        _ => Ok(And(es).into()),
+    }
 }
 
 fn priority_2_terminal(data: &[FinalToken]) -> Result<Expression<String>, ParseTokensError> {
     if data.is_empty() {
         Err(ParseTokensError::EmptySideOfOperator)
     } else if data[0] == FinalToken::Not {
-        Ok(Expression::negate(priority_2_terminal(&data[1..])?))
+        Ok(Not(priority_2_terminal(&data[1..])?).into())
     } else if data.len() > 1 {
         Err(ParseTokensError::UnexpectedLiteralsGroup)
     } else {
+        // data.len() == 1
         match &data[0] {
-            FinalToken::ConstantTrue => Ok(Expression::Constant(true)),
-            FinalToken::ConstantFalse => Ok(Expression::Constant(false)),
-            FinalToken::Literal(name) => Ok(Expression::Literal(name.clone())),
+            FinalToken::ConstantTrue => Ok(Constant(true).into()),
+            FinalToken::ConstantFalse => Ok(Constant(false).into()),
+            FinalToken::Literal(name) => Ok(Literal(name.clone()).into()),
             FinalToken::Parentheses(inner) => Ok(parse_tokens(inner)?),
             _ => unreachable!(
                 "Other tokens are matched by remaining functions, nothing else should remain."
@@ -59,7 +56,7 @@ fn priority_2_terminal(data: &[FinalToken]) -> Result<Expression<String>, ParseT
 
 #[cfg(test)]
 mod tests {
-    use crate::expressions::Expression::{Constant, Literal};
+    use crate::expressions::tests::{bool, var};
     use crate::parser::error::ParseTokensError::EmptySideOfOperator;
     use crate::parser::{tokenize, ParseError};
     use crate::traits::SemanticEq;
@@ -81,7 +78,7 @@ mod tests {
     fn test_binaryand_ok() -> Result<(), ParseError> {
         let input = tokenize("a & b")?;
         let actual = parse_tokens(&input)?;
-        let expected = Expression::binary_and(Literal("a".to_string()), Literal("b".to_string()));
+        let expected = var("a") & var("b");
 
         assert!(actual.semantic_eq(&expected));
         assert_eq!(actual, expected);
@@ -93,11 +90,7 @@ mod tests {
     fn test_naryand_ok() -> Result<(), ParseError> {
         let input = tokenize("a & b & c")?;
         let actual = parse_tokens(&input)?;
-        let expected = Expression::n_ary_and(vec![
-            Literal("a".to_string()),
-            Literal("b".to_string()),
-            Literal("c".to_string()),
-        ]);
+        let expected = var("a") & var("b") & var("c");
 
         assert!(actual.semantic_eq(&expected));
         assert_eq!(actual, expected);
@@ -109,7 +102,7 @@ mod tests {
     fn test_binaryor_ok() -> Result<(), ParseError> {
         let input = tokenize("a | b")?;
         let actual = parse_tokens(&input)?;
-        let expected = Expression::binary_or(Literal("a".to_string()), Literal("b".to_string()));
+        let expected = var("a") | var("b");
 
         assert!(actual.semantic_eq(&expected));
         assert_eq!(actual, expected);
@@ -121,11 +114,7 @@ mod tests {
     fn test_naryor_ok() -> Result<(), ParseError> {
         let input = tokenize("a | b | c")?;
         let actual = parse_tokens(&input)?;
-        let expected = Expression::n_ary_or(vec![
-            Literal("a".to_string()),
-            Literal("b".to_string()),
-            Literal("c".to_string()),
-        ]);
+        let expected = var("a") | var("b") | var("c");
 
         assert!(actual.semantic_eq(&expected));
         assert_eq!(actual, expected);
@@ -137,7 +126,7 @@ mod tests {
     fn test_parentheses_toplevel_ok() -> Result<(), ParseError> {
         let input = tokenize("(a)")?;
         let actual = parse_tokens(&input)?;
-        let expected = Literal("a".to_string());
+        let expected = var("a");
 
         assert!(actual.semantic_eq(&expected));
         assert_eq!(actual, expected);
@@ -149,15 +138,7 @@ mod tests {
     fn test_parentheses_naryor_naryand_ok() -> Result<(), ParseError> {
         let input = tokenize("a | b | (a & b & !c)")?;
         let actual = parse_tokens(&input)?;
-        let expected = Expression::n_ary_or(vec![
-            Literal("a".to_string()),
-            Literal("b".to_string()),
-            Expression::n_ary_and(vec![
-                Literal("a".to_string()),
-                Literal("b".to_string()),
-                Expression::negate(Literal("c".to_string())),
-            ]),
-        ]);
+        let expected = var("a") | var("b") | (var("a") & var("b") & !var("c"));
 
         assert!(actual.semantic_eq(&expected));
         assert_eq!(actual, expected);
@@ -169,12 +150,8 @@ mod tests {
     fn test_parentheses_naryor_naryand_constants_ok() -> Result<(), ParseError> {
         let input = tokenize("F | 0 | False | (T & 1 & True)")?;
         let actual = parse_tokens(&input)?;
-        let expected = Expression::n_ary_or(vec![
-            Constant(false),
-            Constant(false),
-            Constant(false),
-            Expression::n_ary_and(vec![Constant(true), Constant(true), Constant(true)]),
-        ]);
+        let expected =
+            bool(false) | bool(false) | bool(false) | (bool(true) & bool(true) & bool(true));
 
         assert!(actual.semantic_eq(&expected));
         assert_eq!(actual, expected);
@@ -186,15 +163,7 @@ mod tests {
     fn test_priorities_naryor_naryand_ok() -> Result<(), ParseError> {
         let input = tokenize("a | b | a & b & !c")?;
         let actual = parse_tokens(&input)?;
-        let expected = Expression::n_ary_or(vec![
-            Literal("a".to_string()),
-            Literal("b".to_string()),
-            Expression::n_ary_and(vec![
-                Literal("a".to_string()),
-                Literal("b".to_string()),
-                Expression::negate(Literal("c".to_string())),
-            ]),
-        ]);
+        let expected = var("a") | var("b") | (var("a") & var("b") & !var("c"));
 
         assert!(actual.semantic_eq(&expected));
         assert_eq!(actual, expected);


### PR DESCRIPTION
This PR tries to implement the design proposed in #12. It should serve as the basis for discussion regarding which path we want to take.

Unfortunately, @AurumTheEnd was right and we can't make `Expression` implement `Copy` unless all its members implement `Copy`. However, the new design should ensure that cloning any `Expression` is very cheap because it is just `Arc` increment. Hence, I currently tried to follow the convention that `Expression` objects are passed by reference (almost) everywhere, and it is the responsibility of the callee to create a copy if they need it (the caller should not care if the callee makes the copy or not, because with `Arc`, there is no single "true" owner).

List of changes:
 - The `bindings` are mostly unaffected. I've added conversion traits for `RustExpression` and `PythonExpression` because it seemed useful to have that option, but they don't seem to be that important for now.
 - Main changes are in `expressions/mod.rs`, but the code is largely similar, mostly it just removed some of the explicit `Arc` manipulation that is now handled implicitly by `Clone` and the `Expression` constructor(s).
 - Pattern matching works as before, but it is necessary to call `expression.node()` to access the underlying `enum`. I am open to changing the naming scheme here, but I don't have a better name for this method (and `ExpressionNode` in general).
 - The intended "usage pattern" is that `ExpressionNode` is part of the public API, but should be (almost) never used/created explicitly by the end users. Everything interesting still happens using the `Expression` object and the `ExpressionNode` is just a view of the underlying data hidden behind the `Arc` reference. That is why `ExpressionNode` has practically no API as well.
 - I've updated `is_literal` slightly because it allowed nested negation. Maybe this is something that is open to discussion, I am not quite sure. I have not seen it implemented like this elsewhere, but from a certain point of view, it does make sense (since `!!x` is just `x`, might as well call both of them literals).
 - In parser, I slightly change the logic of the recursive methods because it is no longer practical to build an n-ary expression using `fold` without extensive copying. We could still build an `ExpressionNode` instance using `fold`, but this just seemed cleaner.
 - While I was updating the tests, I've added some utility methods and trait implementations to make building test expressions easier. In particular, `var` and `vars` can be used to quickly build `Literal` instance(s). Then, `BitAnd`, `BitOr` and `Not` are implemented for `Expression` in tests. This means we can build the expressions without nesting the enum constructor too much. *The trait implementations are not part of the public API, because I am not sure we want them there. However, in tests, it seemed like an overall obvious win to use them. If you disagree, we don't have to use it though :)*
